### PR TITLE
Switched to using TCP keepalives

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,8 @@
-hash: 2fba0f14eb046d989693da6ca931e1d98966610f34e339c12b226eea90a4c8db
-updated: 2016-07-31T02:34:49.93141699-05:00
+hash: 59777c8684d69a7e00d092fae64f533b6f6cf60261104247aa4be615617a666a
+updated: 2017-08-02T14:51:47.817011415-05:00
 imports:
+- name: github.com/felixge/tcpkeepalive
+  version: 5bb0b2dea91e0de550022159b9571aafc72c08ba
 - name: github.com/getlantern/byteexec
   version: 431d6edd2151495029d77e1c510affa5d89fe168
 - name: github.com/getlantern/context
@@ -27,4 +29,16 @@ imports:
   version: 02f928aad224fbccd50d66edd776fc9d1e9f2f2b
 - name: github.com/oxtoacart/bpool
   version: 4e1c5567d7c2dd59fa4c7c83d34c2f3528b025d6
-devImports: []
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: f6abca593680b2315d2075e0f5e2a9751e3f431a
+  subpackages:
+  - assert

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,6 @@
 hash: 59777c8684d69a7e00d092fae64f533b6f6cf60261104247aa4be615617a666a
 updated: 2017-08-02T14:51:47.817011415-05:00
 imports:
-- name: github.com/felixge/tcpkeepalive
-  version: 5bb0b2dea91e0de550022159b9571aafc72c08ba
 - name: github.com/getlantern/byteexec
   version: 431d6edd2151495029d77e1c510affa5d89fe168
 - name: github.com/getlantern/context

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,3 +4,4 @@ import:
 - package: github.com/getlantern/keyman
 - package: github.com/getlantern/netx
 - package: github.com/oxtoacart/bpool
+- package: github.com/felixge/tcpkeepalive

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,4 +4,3 @@ import:
 - package: github.com/getlantern/keyman
 - package: github.com/getlantern/netx
 - package: github.com/oxtoacart/bpool
-- package: github.com/felixge/tcpkeepalive


### PR DESCRIPTION
For getlantern/lantern-internal#1012

Instead of using idletiming, this relies on TCP keepalives.

cc: @aranhoide @joesis 